### PR TITLE
Draft: Basic strongswan distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@ This repository is meant to provide local & production infrastructure code and a
 So far this is just a demo on local environment with two docker containers :
 - one for deploying a local strongswan
 - one for a deploy a client that connects to the vpn and ping other clients
+
+## Prerequisites
+
+Any CRI compliant software or Docker ( easier on windows )
+
+## Build
+
+```sh
+docker build -t igloovpn/strongswan strongswan
+```
+
+## Run
+
+```sh
+docker run --rm --cap-add=NET_ADMIN -ti igloovpn/strongswan
+```
+
+_Note_: you can exit by hitting Ctrl+C

--- a/strongswan/Dockerfile
+++ b/strongswan/Dockerfile
@@ -1,0 +1,63 @@
+ARG DEBIAN_VERSION=11.6
+
+FROM debian:$DEBIAN_VERSION
+
+ARG STRONGSWAN_VERSION=5.9.8
+
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get -y install curl bzip2 gcc make libssl-dev openssl
+
+WORKDIR build
+
+RUN curl https://download.strongswan.org/strongswan-${STRONGSWAN_VERSION}.tar.bz2 --output strongswan-${STRONGSWAN_VERSION}.tar.bz2 && \
+    curl https://download.strongswan.org/strongswan-${STRONGSWAN_VERSION}.tar.bz2.md5 --output strongswan-${STRONGSWAN_VERSION}.tar.bz2.md5 && \
+    md5sum -c strongswan-${STRONGSWAN_VERSION}.tar.bz2.md5  && \
+    tar --strip-components=1 -xjf strongswan-${STRONGSWAN_VERSION}.tar.bz2 && \
+    rm strongswan-${STRONGSWAN_VERSION}.tar.bz2 strongswan-${STRONGSWAN_VERSION}.tar.bz2.md5
+
+RUN ./configure \
+    --disable-shared \
+    --enable-static \
+    --enable-monolithic \
+    --prefix=/usr \
+    --sysconfdir=/etc \
+    --enable-aesni \
+    --enable-chapoly \
+    --enable-ha \
+    --enable-dhcp \
+    --enable-eap-dynamic \
+    --enable-eap-identity \
+    --enable-eap-md5 \
+    --enable-eap-mschapv2 \
+    --enable-eap-tls \
+    --enable-farp \
+    --enable-files \
+    --enable-gcm \
+    --enable-md4 \
+    --enable-newhope \
+    --enable-ntru \
+    --enable-openssl \
+    --enable-sha3 \
+    --enable-shared \
+    --enable-vici \
+    --disable-aes \
+    --disable-des \
+    --disable-gmp \
+    --disable-hmac \
+    --disable-ikev1 \
+    --disable-md5 \
+    --disable-rc2 \
+    --disable-sha1 \
+    --disable-sha2 \
+    --disable-static \
+    --disable-mysql \
+    --disable-sql
+
+RUN make && make install
+
+EXPOSE 500/udp \
+       4500/udp
+
+ENTRYPOINT ["/usr/sbin/ipsec"]
+CMD ["start", "--nofork"]


### PR DESCRIPTION
Provide a basic strongswan distribution and tooling and assert a simple roadwarrior EAP connexion can be made.

closes #1 

- [x]  provide latest debian + strongswan unoptimized docker image
- [ ]  extend the image to allow creation of EAP credentials with an `exec`
- [ ]  extend the image to run automated connexion test ( generate EAP credentials + connect + ping )
- [ ] update README.md about how to reproduce
- [ ] out-of-box running demo with docker compose